### PR TITLE
Convert SVG before building LaTeX docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ author = 'Jonathan E. Guyer'
 extensions = ['sphinx.ext.autosummary',
               'sphinx.ext.doctest',
               'sphinx.ext.napoleon',
+              'sphinx.ext.imgconverter',
               'matplotlib.sphinxext.plot_directive'
               ]
 


### PR DESCRIPTION
On Debian 11, configuring Sphinx to use `imgconverter` resolves the breakage due to SVGs in the LaTeX source (`make latexpdf`, &c).